### PR TITLE
fixes #1: request_dcp_message must keep receiving until full message is accumulated

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ example is provided below.
 - For more information about search criteria, check opendcs
   doc [here](https://opendcs-env.readthedocs.io/en/stable/lrgs-userguide.html#search-criteria-file-format).
 
+## Tests
+
+Run tests using: `python -m unittest discover`
+
+See also: https://www.pythontutorial.net/python-unit-testing/python-run-unittest/
+
 ## Reference
 
 [DCP Data Service (DDS) Protocol Specification](https://dcs1.noaa.gov/LRGS/DCP-Data-Service-14.pdf), Version 14

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ example is provided below.
 - For more information about search criteria, check opendcs
   doc [here](https://opendcs-env.readthedocs.io/en/stable/lrgs-userguide.html#search-criteria-file-format).
 
+## Reference
+
+[DCP Data Service (DDS) Protocol Specification](https://dcs1.noaa.gov/LRGS/DCP-Data-Service-14.pdf), Version 14
+
 ## Contributors
 
 - [Manoj Kotteda](https://github.com/orgs/dcspy/people/manojkotteda)

--- a/dcspy/ldds_client.py
+++ b/dcspy/ldds_client.py
@@ -51,7 +51,7 @@ class BasicClient:
             if self.timeout is not None:
                 self.socket.settimeout(self.timeout)
             self.socket.connect((self.host, self.port))
-            self.socket.settimeout(60)
+            self.socket.settimeout(60) # TODO: should this also be a param?
             self.last_connect_attempt = time.time()
             write_debug(f"Successfully connected to {self.host}:{self.port}")
         except socket.timeout as ex:
@@ -94,14 +94,14 @@ class BasicClient:
 
         :param buffer_size: The size of the buffer to use when receiving data.
         :return: The received byte data, guaranteed to contain at least one byte
-        :raises IOError: If the socket is not connected.
+        :raises IOError: If the socket is not connected or EOF is reached.
         """
         if self.socket is None:
             raise IOError("BasicClient socket closed.")
-        r = self.socket.recv(buffer_size)
-        if len(r) == 0:
+        data = self.socket.recv(buffer_size)
+        if len(data) == 0:
             raise IOError("BasicClient socket closed.")
-        return r
+        return data
 
 
 class LddsClient(BasicClient):
@@ -170,8 +170,8 @@ class LddsClient(BasicClient):
         bytes_to_send = message.to_bytes()
         self.send_data(bytes_to_send)
 
-        # receive and parse the header
         try:
+            # receive and parse the header
             rx_data = bytearray()
             response = None
             while response is None:
@@ -194,7 +194,6 @@ class LddsClient(BasicClient):
             
         except Exception as e:
             write_error(f"Error receiving DCP message: {e}")
-            raise
 
         return
 

--- a/main.py
+++ b/main.py
@@ -19,4 +19,5 @@ if __name__ == "__main__":
                               search_criteria="./test_search_criteria.json",
                               host="cdadata.wcda.noaa.gov",
                               )
-    print("\n".join(messages))
+    for m in messages:
+        print(f"[{m}]")

--- a/tests/test_dcp_message.py
+++ b/tests/test_dcp_message.py
@@ -11,7 +11,7 @@ class TestDcpMessage(unittest.TestCase):
                         b"A081B07E24204144853G30-0HN096WUP00012`BST@KY@KYg ")
         ldds_message = LddsMessage.create(LddsMessageIds.dcp_block, message_data)
         dcp_messages = DcpMessage.explode(ldds_message)
-        self.assertEqual(dcp_messages, ["A081B07E24204153353G30-0NN096WUB00012`BST@KZ@KZh ",
-                                        "A081B07E24204151853G30-0HN096WUB00012`BST@KZ@KYh ",
-                                        "A081B07E24204150353G29-0HN096WUP00012`BST@KY@KYg ",
-                                        "A081B07E24204144853G30-0HN096WUP00012`BST@KY@KYg "])
+        self.assertEqual(dcp_messages, [DcpMessage.parse("A081B07E24204153353G30-0NN096WUB00012`BST@KZ@KZh "),
+                                        DcpMessage.parse("A081B07E24204151853G30-0HN096WUB00012`BST@KZ@KYh "),
+                                        DcpMessage.parse("A081B07E24204150353G29-0HN096WUP00012`BST@KY@KYg "),
+                                        DcpMessage.parse("A081B07E24204144853G30-0HN096WUP00012`BST@KY@KYg ")])

--- a/tests/test_ldds_message.py
+++ b/tests/test_ldds_message.py
@@ -4,16 +4,20 @@ from dcspy.server_exceptions import ServerError
 
 
 class TestLddsMessage(unittest.TestCase):
-    def test_parse_w_error(self):
-        parsed_message, parsed_error = LddsMessage.parse(b"FAF0m00030?55,0,Server requires SHA-256.")
+    def test_check_error(self):
+        msg = b"FAF0m00030?55,0,Server requires SHA-256."
+        parsed_message = LddsMessage.parse_header(msg)
+        parsed_message.message_data = msg[10:]
+        parsed_error = parsed_message.check_error()
         server_error = ServerError(message="Server requires SHA-256.", server_code_no=55, system_code_no=0)
-        assert parsed_message is None
         self.assertEqual(parsed_error, server_error)
 
     def test_parse_create(self):
         created_message = LddsMessage.create(LddsMessageIds.dcp_block,
                                              b"A081B07E24204153353G30-0NN096WUB00012`BST@KZ@KZh ")
-        parsed_message, _ = LddsMessage.parse(b'FAF0n00049A081B07E24204153353G30-0NN096WUB00012`BST@KZ@KZh ')
+        msg = b'FAF0n00049A081B07E24204153353G30-0NN096WUB00012`BST@KZ@KZh '
+        parsed_message = LddsMessage.parse_header(msg)
+        parsed_message.message_data = msg[10:]
         self.assertEqual(parsed_message, created_message)
 
     def test_to_bytes(self):


### PR DESCRIPTION
This is a preliminary PR, need to test more...
The issue is that request_dcp_message needs to properly read a full message and not return with whatever the first socket.recv returned. This PR fixes that by having with look over receive_data until a header is received, then parse the header, then read the number of bytes remaining and return the full message.
Right now it is assumed that there is no pipelining, so there should never be more bytes received than one message, this could easily be handled if necessary by using the buffer_size param to receive_data.